### PR TITLE
Auth headers fixed, modules get request has " " again now

### DIFF
--- a/app/scripts/account/login.controller.js
+++ b/app/scripts/account/login.controller.js
@@ -19,8 +19,9 @@ define(['./account.module'], function () {
         request: function (config) {
           if (AuthService.isAuthenticated()) {
             var authentication = AuthService.getAuthentication();
-            var token = window.btoa(authentication.username + ':' + authentication.password);
+            var token = (window.btoa(authentication.username + ':' + 'password'/*authentication.password*/)).toString('base64');
             config.headers.Authorization = 'Basic ' + token;
+            console.log("***********",token, authentication.username);
           }
           return config;
         }

--- a/app/scripts/learn/category.controller.js
+++ b/app/scripts/learn/category.controller.js
@@ -34,10 +34,7 @@ define(['./learn.module'], function () {
 
     $http({
       method: 'GET',
-      url: '/api/modules?filters={\'parent_id\':null, \'category_id\': ' + $stateParams.categoryId + '}',
-      headers: {
-        'Authorization': 'Basic cHM6cGFzc3dvcmQ='
-      }
+      url: '/api/modules?filters={"parent_id":null, "category_id": ' + $stateParams.categoryId + '}'
     }).then(function (res) {
       console.log(res.data);
       $scope.topBucket = res.data;

--- a/app/scripts/learn/learn.controller.js
+++ b/app/scripts/learn/learn.controller.js
@@ -15,9 +15,7 @@ define(['./learn.module'], function () {
   angular.module('liberry.learnModule')
     .controller('learn.LearnCtrl', ['$scope', '$http', function ($scope, $http) {
       $http({
-        method: 'GET', url: '/api/categories', headers: {
-          'Authorization': 'Basic cHM6cGFzc3dvcmQ='
-        }
+        method: 'GET', url: '/api/categories'
       }).then(function (res) {
         $scope.topBucket = res.data;
       });


### PR DESCRIPTION
>Auth headers base64 encoded.
>Password in header set to static string like everywhere else.
>api/modules get request params back in " " instead of \' \'